### PR TITLE
Security Fix for Insecure Encryption - huntr.dev

### DIFF
--- a/lib/AsymmetriCrypt/Crypter.php
+++ b/lib/AsymmetriCrypt/Crypter.php
@@ -23,7 +23,7 @@ class Crypter
 
     public static function encrypt($message, PublicKey $pubkey, $url_safe = false)
     {
-        openssl_public_encrypt($message, $out, $pubkey->getKey());
+        openssl_public_encrypt($message, $out, $pubkey->getKey(), OPENSSL_PKCS1_OAEP_PADDING);
         $out = chunk_split(base64_encode($out));
 
         if ($url_safe) {
@@ -36,7 +36,7 @@ class Crypter
     public static function decrypt($message, PrivateKey $privkey)
     {
         $message = base64_decode(strtr($message, '-_,', '+/='));
-        openssl_private_decrypt($message, $out, $privkey->getKey());
+        openssl_private_decrypt($message, $out, $privkey->getKey(), OPENSSL_PKCS1_OAEP_PADDING);
 
         return $out;
     }


### PR DESCRIPTION
https://huntr.dev/users/Mik317 has fixed the Insecure Encryption vulnerability 🔨. Mik317 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/AsymmetriCrypt/pull/1
GitHub Issue | https://github.com/Cosmicist/AsymmetriCrypt/issues/4
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/packagist/asymmetricrypt/1/README.md

### User Comments:

Adding `OPENSSL_PKCS1_OAEP_PADDING` as `padding` to prevent `Bleichenbacher's` attack in both `encrypt/decrypt`

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-asymmetricrypt

### ⚙️ Description *

The `encryption` and `decryption` process were vulnerable against the `Bleichenbacher's attack`, which is a `padding oracle vulnerability` disclosed in the 98'.
The issue was about the wrong `padding` utilized, which allowed to `retrieve` the encrypted content.
The `OPENSSL_PKCS1_PADDING` version, aka `PKCS v1.5` was vulnerable (is the one set by default when using `openssl_*` methods), while the `PKCS v2.0` isn't anymore (it's also called `OAEP`).

### 💻 Technical Description *

I inserted in both `encrypt/decrypt` methods the padding option set to `OPENSSL_PKCS1_OAEP_PADDING` (`integer value ==4`), which prevents this attack to success :smile:.
You can find more here: https://paragonie.com/blog/2016/12/everything-you-know-about-public-key-encryption-in-php-is-wrong

> The solution is to specify OPENSSL_PKCS1_OAEP_PADDING whenever you use either function. This constant forces the use of OAEP padding instead of insecure PKCS1 v1.5 padding.

### 🐛 Proof of Concept (PoC) *

No POC provided, but fix was really easy :smile:

### 🔥 Proof of Fix (PoF) *

I implemented the most known `fix` to avoid this type of attack

### 👍 User Acceptance Testing (UAT)

Just specified a different value on the `padding` option which is different from the default one (vulnerable).